### PR TITLE
PE-5836: move nodeadm scripts & bin dirs to /opt/nodeadmutil as nodeadm upgrade wipes /opt/nodeadm

### DIFF
--- a/.github/workflows/provider-packaging.yaml
+++ b/.github/workflows/provider-packaging.yaml
@@ -13,7 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: docker-practice/actions-setup-docker@master
       - uses: earthly/actions-setup@v1
         with:
           version: "v0.6.30"
@@ -25,7 +24,6 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
-      - uses: docker-practice/actions-setup-docker@master
       - uses: earthly/actions-setup@v1
         with:
           version: "v0.6.30"

--- a/.github/workflows/provider-packaging.yaml
+++ b/.github/workflows/provider-packaging.yaml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
       - uses: earthly/actions-setup@v1
         with:
           version: "v0.6.30"
@@ -24,6 +25,7 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
       - uses: earthly/actions-setup@v1
         with:
           version: "v0.6.30"

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -26,6 +26,7 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
       - uses: earthly/actions-setup@v1
         with:
           version: "v0.6.30"

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -26,7 +26,6 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
-      - uses: docker-practice/actions-setup-docker@master
       - uses: earthly/actions-setup@v1
         with:
           version: "v0.6.30"

--- a/Earthfile
+++ b/Earthfile
@@ -67,7 +67,7 @@ build-provider-package:
     FROM scratch
 
     COPY +build-provider/agent-provider-nodeadm /system/providers/agent-provider-nodeadm
-    COPY scripts/ /opt/nodeadm/scripts/
+    COPY scripts/ /opt/nodeadmutil/scripts/
 
     SAVE IMAGE --push $IMAGE_REPOSITORY/provider-nodeadm:latest
     SAVE IMAGE --push $IMAGE_REPOSITORY/provider-nodeadm:${VERSION}
@@ -121,8 +121,8 @@ docker:
     ENV OS_LABEL=${BASE_IMAGE_TAG}_${NODEADM_VERSION_TAG}_${VERSION}
     RUN envsubst >>/etc/os-release </usr/lib/os-release.tmpl
 
-    RUN mkdir -p /opt/nodeadm/scripts
-    COPY scripts/* /opt/nodeadm/scripts/
+    RUN mkdir -p /opt/nodeadmutil/scripts
+    COPY scripts/* /opt/nodeadmutil/scripts/
 
     COPY +build-provider/agent-provider-nodeadm /system/providers/agent-provider-nodeadm
 

--- a/pkg/provider/testdata/iam-ra/expected.yaml
+++ b/pkg/provider/testdata/iam-ra/expected.yaml
@@ -130,8 +130,9 @@ Stages:
     Users: null
   - After: null
     Commands:
-    - 'bash /opt/nodeadm/scripts/nodeadm-install.sh 1.30.0 iam-ra /opt/nodeadm false '
-    - touch /opt/nodeadm/nodeadm.install
+    - 'bash /opt/nodeadmutil/scripts/nodeadm-install.sh 1.30.0 iam-ra /opt/nodeadmutil
+      false '
+    - touch /opt/nodeadmutil/nodeadm.install
     DataSources:
       Path: ""
       Providers: null
@@ -159,7 +160,7 @@ Stages:
       Path: ""
       URL: ""
     Hostname: ""
-    If: '[ ! -f /opt/nodeadm/nodeadm.install ]'
+    If: '[ ! -f /opt/nodeadmutil/nodeadm.install ]'
     Layout:
       Device: null
       Expand: null
@@ -184,8 +185,8 @@ Stages:
     Users: null
   - After: null
     Commands:
-    - 'bash /opt/nodeadm/scripts/nodeadm-upgrade.sh 1.30.0 /opt/nodeadm/node-config.yaml
-      /opt/nodeadm false '
+    - 'bash /opt/nodeadmutil/scripts/nodeadm-upgrade.sh 1.30.0 /opt/nodeadmutil/node-config.yaml
+      /opt/nodeadmutil false '
     DataSources:
       Path: ""
       Providers: null
@@ -276,7 +277,7 @@ Stages:
       Group: 0
       Owner: 0
       OwnerString: ""
-      Path: /opt/nodeadm/node-config.yaml
+      Path: /opt/nodeadmutil/node-config.yaml
       Permissions: 416
     - Content: |
         -----BEGIN CERTIFICATE-----
@@ -357,9 +358,9 @@ Stages:
     Users: null
   - After: null
     Commands:
-    - 'bash /opt/nodeadm/scripts/nodeadm-init.sh /opt/nodeadm/node-config.yaml /opt/nodeadm
-      false '
-    - touch /opt/nodeadm/nodeadm.init
+    - 'bash /opt/nodeadmutil/scripts/nodeadm-init.sh /opt/nodeadmutil/node-config.yaml
+      /opt/nodeadmutil false '
+    - touch /opt/nodeadmutil/nodeadm.init
     DataSources:
       Path: ""
       Providers: null
@@ -387,7 +388,7 @@ Stages:
       Path: ""
       URL: ""
     Hostname: ""
-    If: '[ ! -f /opt/nodeadm/nodeadm.init ]'
+    If: '[ ! -f /opt/nodeadmutil/nodeadm.init ]'
     Layout:
       Device: null
       Expand: null

--- a/pkg/provider/testdata/ssm-custom/expected.yaml
+++ b/pkg/provider/testdata/ssm-custom/expected.yaml
@@ -130,9 +130,9 @@ Stages:
     Users: null
   - After: null
     Commands:
-    - 'bash /opt/nodeadm/scripts/nodeadm-install.sh 1.30.0 ssm-custom /opt/nodeadm
+    - 'bash /opt/nodeadmutil/scripts/nodeadm-install.sh 1.30.0 ssm-custom /opt/nodeadmutil
       false '
-    - touch /opt/nodeadm/nodeadm.install
+    - touch /opt/nodeadmutil/nodeadm.install
     DataSources:
       Path: ""
       Providers: null
@@ -160,7 +160,7 @@ Stages:
       Path: ""
       URL: ""
     Hostname: ""
-    If: '[ ! -f /opt/nodeadm/nodeadm.install ]'
+    If: '[ ! -f /opt/nodeadmutil/nodeadm.install ]'
     Layout:
       Device: null
       Expand: null
@@ -185,8 +185,8 @@ Stages:
     Users: null
   - After: null
     Commands:
-    - 'bash /opt/nodeadm/scripts/nodeadm-upgrade.sh 1.30.0 /opt/nodeadm/node-config.yaml
-      /opt/nodeadm false '
+    - 'bash /opt/nodeadmutil/scripts/nodeadm-upgrade.sh 1.30.0 /opt/nodeadmutil/node-config.yaml
+      /opt/nodeadmutil false '
     DataSources:
       Path: ""
       Providers: null
@@ -282,7 +282,7 @@ Stages:
       Group: 0
       Owner: 0
       OwnerString: ""
-      Path: /opt/nodeadm/node-config.yaml
+      Path: /opt/nodeadmutil/node-config.yaml
       Permissions: 416
     Git:
       Auth:
@@ -321,9 +321,9 @@ Stages:
     Users: null
   - After: null
     Commands:
-    - 'bash /opt/nodeadm/scripts/nodeadm-init.sh /opt/nodeadm/node-config.yaml /opt/nodeadm
-      false '
-    - touch /opt/nodeadm/nodeadm.init
+    - 'bash /opt/nodeadmutil/scripts/nodeadm-init.sh /opt/nodeadmutil/node-config.yaml
+      /opt/nodeadmutil false '
+    - touch /opt/nodeadmutil/nodeadm.init
     DataSources:
       Path: ""
       Providers: null
@@ -351,7 +351,7 @@ Stages:
       Path: ""
       URL: ""
     Hostname: ""
-    If: '[ ! -f /opt/nodeadm/nodeadm.init ]'
+    If: '[ ! -f /opt/nodeadmutil/nodeadm.init ]'
     Layout:
       Device: null
       Expand: null

--- a/pkg/provider/testdata/ssm/expected.yaml
+++ b/pkg/provider/testdata/ssm/expected.yaml
@@ -130,8 +130,9 @@ Stages:
     Users: null
   - After: null
     Commands:
-    - 'bash /opt/nodeadm/scripts/nodeadm-install.sh 1.30.0 ssm /opt/nodeadm false '
-    - touch /opt/nodeadm/nodeadm.install
+    - 'bash /opt/nodeadmutil/scripts/nodeadm-install.sh 1.30.0 ssm /opt/nodeadmutil
+      false '
+    - touch /opt/nodeadmutil/nodeadm.install
     DataSources:
       Path: ""
       Providers: null
@@ -159,7 +160,7 @@ Stages:
       Path: ""
       URL: ""
     Hostname: ""
-    If: '[ ! -f /opt/nodeadm/nodeadm.install ]'
+    If: '[ ! -f /opt/nodeadmutil/nodeadm.install ]'
     Layout:
       Device: null
       Expand: null
@@ -184,8 +185,8 @@ Stages:
     Users: null
   - After: null
     Commands:
-    - 'bash /opt/nodeadm/scripts/nodeadm-upgrade.sh 1.30.0 /opt/nodeadm/node-config.yaml
-      /opt/nodeadm false '
+    - 'bash /opt/nodeadmutil/scripts/nodeadm-upgrade.sh 1.30.0 /opt/nodeadmutil/node-config.yaml
+      /opt/nodeadmutil false '
     DataSources:
       Path: ""
       Providers: null
@@ -274,7 +275,7 @@ Stages:
       Group: 0
       Owner: 0
       OwnerString: ""
-      Path: /opt/nodeadm/node-config.yaml
+      Path: /opt/nodeadmutil/node-config.yaml
       Permissions: 416
     Git:
       Auth:
@@ -313,9 +314,9 @@ Stages:
     Users: null
   - After: null
     Commands:
-    - 'bash /opt/nodeadm/scripts/nodeadm-init.sh /opt/nodeadm/node-config.yaml /opt/nodeadm
-      false '
-    - touch /opt/nodeadm/nodeadm.init
+    - 'bash /opt/nodeadmutil/scripts/nodeadm-init.sh /opt/nodeadmutil/node-config.yaml
+      /opt/nodeadmutil false '
+    - touch /opt/nodeadmutil/nodeadm.init
     DataSources:
       Path: ""
       Providers: null
@@ -343,7 +344,7 @@ Stages:
       Path: ""
       URL: ""
     Hostname: ""
-    If: '[ ! -f /opt/nodeadm/nodeadm.init ]'
+    If: '[ ! -f /opt/nodeadmutil/nodeadm.init ]'
     Layout:
       Device: null
       Expand: null

--- a/pkg/stages/pre_install.go
+++ b/pkg/stages/pre_install.go
@@ -15,7 +15,7 @@ import (
 const (
 	envPrefix   = "Environment="
 	k8sNoProxy  = ".svc,.svc.cluster,.svc.cluster.local"
-	nodeadmRoot = "/opt/nodeadm"
+	nodeadmRoot = "/opt/nodeadmutil"
 )
 
 var (


### PR DESCRIPTION
Deal with the fact that the v1.0.0 release of `nodeadm` [wipes `/opt/nodeadm` during `nodeadm upgrade`](https://github.com/aws/eks-hybrid/blob/main/internal/tracker/artifacts.go#L74).

- relocate `/opt/nodeadm/scripts` to `/opt/nodeadmutil/scripts`
- expect `nodeadm` binary to reside under `/opt/nodeadmutil/bin`