### PR TITLE
PE-5966: remove early exits from nodeadm-upgrade.sh

### DIFF
--- a/scripts/nodeadm-upgrade.sh
+++ b/scripts/nodeadm-upgrade.sh
@@ -43,7 +43,7 @@ run_upgrade() {
     if ! [ -f "$root_path/sentinel_kubernetes_version" ]; then
       echo "$kubernetes_version" > "$root_path/sentinel_kubernetes_version"
       echo "upgrade is a no-op; created sentinel file with version: $kubernetes_version"
-      exit 0
+      return
     fi
 
     old_version=$(cat "$root_path/sentinel_kubernetes_version")
@@ -57,7 +57,7 @@ run_upgrade() {
     if [ "$current_version" = "$old_version" ]
     then
       echo "node is on latest version: $current_version"
-      exit 0
+      return
     fi
 
     # Backup admin.conf if it exists, as nodeadm upgrade wipes /etc/kubernetes


### PR DESCRIPTION
Fix the fact that early exits when the k8s version remains the same are preventing reconfigurations from being applied by `nodeadm init`.

These include:
- Edits to the kubelet and containerd config in the k8s profile
- Edits to the VPN server IP
- Edits to the EKS authentication configuration 