### PR TITLE
ci: enable automerge in renovate.json to trigger renovate-approve bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,51 @@
     "config:recommended",
     ":semanticCommitTypeAll(deps)",
     "group:allNonMajor"
+  ],
+  "addLabels": [
+    "dependencies"
+  ],
+  "postUpdateOptions": [
+    "gomodTidy",
+    "gomodMassage"
+  ],
+  "packageRules": [
+    {
+      "matchUpdateTypes": [
+        "pin",
+        "pinDigest",
+        "digest"
+      ],
+      "addLabels": [
+        "pin"
+      ],
+      "automerge": true
+    },
+    {
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": true
+    },
+    {
+      "matchManagers": [
+        "gomod"
+      ],
+      "addLabels": [
+        "go"
+      ],
+      "automerge": true
+    },
+    {
+      "matchManagers": [
+        "github-actions"
+      ],
+      "addLabels": [
+        "github_actions"
+      ],
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
The renovate-approve bot will only auto-approve PRs if they're configured for automerge.