### PR TITLE
PE-6070: ensure nodeadm config exists before nodeadm upgrade

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -81,11 +81,16 @@ func NodeadmProvider(cluster clusterplugin.Cluster) yip.YipConfig {
 		)
 	}
 
+	// prepare filesystem, proxy, and nodeadm config
 	bootBeforeStages := stages.PreInstallBootBeforeStages(cluster.Env, nc)
+
+	// run `nodeadm install` / `nodeadm upgrade` in agent-mode
 	if handleDependencies {
 		bootBeforeStages = append(bootBeforeStages, stages.InstallBootBeforeStages(nc, proxyArgs)...)
 	}
-	bootBeforeStages = append(bootBeforeStages, stages.InitBootBeforeStages(nc, proxyArgs, handleDependencies)...)
+
+	// run `nodeadm init`
+	bootBeforeStages = append(bootBeforeStages, stages.InitBootBeforeStages(proxyArgs, handleDependencies)...)
 
 	cfg := yip.YipConfig{
 		Name: "Kairos Provider Nodeadm",

--- a/pkg/provider/testdata/iam-ra-agent/expected.yaml
+++ b/pkg/provider/testdata/iam-ra-agent/expected.yaml
@@ -141,127 +141,6 @@ Stages:
     UnpackImages: null
     Users: null
   - After: null
-    Commands:
-    - 'bash /opt/nodeadmutil/scripts/nodeadm-install.sh 1.30.0 iam-ra /opt/nodeadmutil
-      false '
-    - touch /opt/nodeadmutil/nodeadm.install
-    DataSources:
-      Path: ""
-      Providers: null
-    DeleteEntities: null
-    Directories: null
-    Dns:
-      DnsOptions: null
-      DnsSearch: null
-      Nameservers: null
-      Path: ""
-    Downloads: null
-    EnsureEntities: null
-    Environment: null
-    EnvironmentFile: ""
-    Files: null
-    Git:
-      Auth:
-        Insecure: false
-        Password: ""
-        PrivateKey: ""
-        PublicKey: ""
-        Username: ""
-      Branch: ""
-      BranchOnly: false
-      Path: ""
-      URL: ""
-    Hostname: ""
-    If: '[ ! -f /opt/nodeadmutil/nodeadm.install ]'
-    Layout:
-      Device: null
-      Expand: null
-      Parts: null
-    Modules: null
-    Name: Run Nodeadm Install
-    Node: ""
-    OnlyIfArch: ""
-    OnlyIfOs: ""
-    OnlyIfOsVersion: ""
-    OnlyIfServiceManager: ""
-    Packages:
-      Install: null
-      Refresh: false
-      Remove: null
-      Upgrade: false
-    SSHKeys: null
-    Sysctl: null
-    Systemctl:
-      Disable: null
-      Enable: null
-      Mask: null
-      Overrides: null
-      Start: null
-    SystemdFirstBoot: null
-    TimeSyncd: null
-    UnpackImages: null
-    Users: null
-  - After: null
-    Commands:
-    - 'bash /opt/nodeadmutil/scripts/nodeadm-upgrade.sh 1.30.0 /opt/nodeadmutil/node-config.yaml
-      /opt/nodeadmutil false '
-    DataSources:
-      Path: ""
-      Providers: null
-    DeleteEntities: null
-    Directories: null
-    Dns:
-      DnsOptions: null
-      DnsSearch: null
-      Nameservers: null
-      Path: ""
-    Downloads: null
-    EnsureEntities: null
-    Environment: null
-    EnvironmentFile: ""
-    Files: null
-    Git:
-      Auth:
-        Insecure: false
-        Password: ""
-        PrivateKey: ""
-        PublicKey: ""
-        Username: ""
-      Branch: ""
-      BranchOnly: false
-      Path: ""
-      URL: ""
-    Hostname: ""
-    If: ""
-    Layout:
-      Device: null
-      Expand: null
-      Parts: null
-    Modules: null
-    Name: Run Nodeadm Upgrade
-    Node: ""
-    OnlyIfArch: ""
-    OnlyIfOs: ""
-    OnlyIfOsVersion: ""
-    OnlyIfServiceManager: ""
-    Packages:
-      Install: null
-      Refresh: false
-      Remove: null
-      Upgrade: false
-    SSHKeys: null
-    Sysctl: null
-    Systemctl:
-      Disable: null
-      Enable: null
-      Mask: null
-      Overrides: null
-      Start: null
-    SystemdFirstBoot: null
-    TimeSyncd: null
-    UnpackImages: null
-    Users: null
-  - After: null
     Commands: null
     DataSources:
       Path: ""
@@ -364,6 +243,127 @@ Stages:
       Parts: null
     Modules: null
     Name: Generate nodeadm config file
+    Node: ""
+    OnlyIfArch: ""
+    OnlyIfOs: ""
+    OnlyIfOsVersion: ""
+    OnlyIfServiceManager: ""
+    Packages:
+      Install: null
+      Refresh: false
+      Remove: null
+      Upgrade: false
+    SSHKeys: null
+    Sysctl: null
+    Systemctl:
+      Disable: null
+      Enable: null
+      Mask: null
+      Overrides: null
+      Start: null
+    SystemdFirstBoot: null
+    TimeSyncd: null
+    UnpackImages: null
+    Users: null
+  - After: null
+    Commands:
+    - 'bash /opt/nodeadmutil/scripts/nodeadm-install.sh 1.30.0 iam-ra /opt/nodeadmutil
+      false '
+    - touch /opt/nodeadmutil/nodeadm.install
+    DataSources:
+      Path: ""
+      Providers: null
+    DeleteEntities: null
+    Directories: null
+    Dns:
+      DnsOptions: null
+      DnsSearch: null
+      Nameservers: null
+      Path: ""
+    Downloads: null
+    EnsureEntities: null
+    Environment: null
+    EnvironmentFile: ""
+    Files: null
+    Git:
+      Auth:
+        Insecure: false
+        Password: ""
+        PrivateKey: ""
+        PublicKey: ""
+        Username: ""
+      Branch: ""
+      BranchOnly: false
+      Path: ""
+      URL: ""
+    Hostname: ""
+    If: '[ ! -f /opt/nodeadmutil/nodeadm.install ]'
+    Layout:
+      Device: null
+      Expand: null
+      Parts: null
+    Modules: null
+    Name: Run Nodeadm Install
+    Node: ""
+    OnlyIfArch: ""
+    OnlyIfOs: ""
+    OnlyIfOsVersion: ""
+    OnlyIfServiceManager: ""
+    Packages:
+      Install: null
+      Refresh: false
+      Remove: null
+      Upgrade: false
+    SSHKeys: null
+    Sysctl: null
+    Systemctl:
+      Disable: null
+      Enable: null
+      Mask: null
+      Overrides: null
+      Start: null
+    SystemdFirstBoot: null
+    TimeSyncd: null
+    UnpackImages: null
+    Users: null
+  - After: null
+    Commands:
+    - 'bash /opt/nodeadmutil/scripts/nodeadm-upgrade.sh 1.30.0 /opt/nodeadmutil/node-config.yaml
+      /opt/nodeadmutil false '
+    DataSources:
+      Path: ""
+      Providers: null
+    DeleteEntities: null
+    Directories: null
+    Dns:
+      DnsOptions: null
+      DnsSearch: null
+      Nameservers: null
+      Path: ""
+    Downloads: null
+    EnsureEntities: null
+    Environment: null
+    EnvironmentFile: ""
+    Files: null
+    Git:
+      Auth:
+        Insecure: false
+        Password: ""
+        PrivateKey: ""
+        PublicKey: ""
+        Username: ""
+      Branch: ""
+      BranchOnly: false
+      Path: ""
+      URL: ""
+    Hostname: ""
+    If: ""
+    Layout:
+      Device: null
+      Expand: null
+      Parts: null
+    Modules: null
+    Name: Run Nodeadm Upgrade
     Node: ""
     OnlyIfArch: ""
     OnlyIfOs: ""

--- a/pkg/provider/testdata/ssm-agent/expected.yaml
+++ b/pkg/provider/testdata/ssm-agent/expected.yaml
@@ -141,6 +141,87 @@ Stages:
     UnpackImages: null
     Users: null
   - After: null
+    Commands: null
+    DataSources:
+      Path: ""
+      Providers: null
+    DeleteEntities: null
+    Directories: null
+    Dns:
+      DnsOptions: null
+      DnsSearch: null
+      Nameservers: null
+      Path: ""
+    Downloads: null
+    EnsureEntities: null
+    Environment: null
+    EnvironmentFile: ""
+    Files:
+    - Content: |
+        apiVersion: node.eks.aws/v1alpha1
+        kind: NodeConfig
+        metadata:
+          creationTimestamp: null
+        spec:
+          cluster:
+            name: eks-hybrid-cluster
+            region: us-east-1
+          containerd: {}
+          hybrid:
+            ssm:
+              activationCode: 12345678-1234-1234-1234-123456789012
+              activationId: 12345678-1234-1234-1234-123456789012
+          instance:
+            localStorage: {}
+          kubelet: {}
+      Encoding: ""
+      Group: 0
+      Owner: 0
+      OwnerString: ""
+      Path: /opt/nodeadmutil/node-config.yaml
+      Permissions: 416
+    Git:
+      Auth:
+        Insecure: false
+        Password: ""
+        PrivateKey: ""
+        PublicKey: ""
+        Username: ""
+      Branch: ""
+      BranchOnly: false
+      Path: ""
+      URL: ""
+    Hostname: ""
+    If: ""
+    Layout:
+      Device: null
+      Expand: null
+      Parts: null
+    Modules: null
+    Name: Generate nodeadm config file
+    Node: ""
+    OnlyIfArch: ""
+    OnlyIfOs: ""
+    OnlyIfOsVersion: ""
+    OnlyIfServiceManager: ""
+    Packages:
+      Install: null
+      Refresh: false
+      Remove: null
+      Upgrade: false
+    SSHKeys: null
+    Sysctl: null
+    Systemctl:
+      Disable: null
+      Enable: null
+      Mask: null
+      Overrides: null
+      Start: null
+    SystemdFirstBoot: null
+    TimeSyncd: null
+    UnpackImages: null
+    Users: null
+  - After: null
     Commands:
     - 'bash /opt/nodeadmutil/scripts/nodeadm-install.sh 1.30.0 ssm /opt/nodeadmutil
       false '
@@ -239,87 +320,6 @@ Stages:
       Parts: null
     Modules: null
     Name: Run Nodeadm Upgrade
-    Node: ""
-    OnlyIfArch: ""
-    OnlyIfOs: ""
-    OnlyIfOsVersion: ""
-    OnlyIfServiceManager: ""
-    Packages:
-      Install: null
-      Refresh: false
-      Remove: null
-      Upgrade: false
-    SSHKeys: null
-    Sysctl: null
-    Systemctl:
-      Disable: null
-      Enable: null
-      Mask: null
-      Overrides: null
-      Start: null
-    SystemdFirstBoot: null
-    TimeSyncd: null
-    UnpackImages: null
-    Users: null
-  - After: null
-    Commands: null
-    DataSources:
-      Path: ""
-      Providers: null
-    DeleteEntities: null
-    Directories: null
-    Dns:
-      DnsOptions: null
-      DnsSearch: null
-      Nameservers: null
-      Path: ""
-    Downloads: null
-    EnsureEntities: null
-    Environment: null
-    EnvironmentFile: ""
-    Files:
-    - Content: |
-        apiVersion: node.eks.aws/v1alpha1
-        kind: NodeConfig
-        metadata:
-          creationTimestamp: null
-        spec:
-          cluster:
-            name: eks-hybrid-cluster
-            region: us-east-1
-          containerd: {}
-          hybrid:
-            ssm:
-              activationCode: 12345678-1234-1234-1234-123456789012
-              activationId: 12345678-1234-1234-1234-123456789012
-          instance:
-            localStorage: {}
-          kubelet: {}
-      Encoding: ""
-      Group: 0
-      Owner: 0
-      OwnerString: ""
-      Path: /opt/nodeadmutil/node-config.yaml
-      Permissions: 416
-    Git:
-      Auth:
-        Insecure: false
-        Password: ""
-        PrivateKey: ""
-        PublicKey: ""
-        Username: ""
-      Branch: ""
-      BranchOnly: false
-      Path: ""
-      URL: ""
-    Hostname: ""
-    If: ""
-    Layout:
-      Device: null
-      Expand: null
-      Parts: null
-    Modules: null
-    Name: Generate nodeadm config file
     Node: ""
     OnlyIfArch: ""
     OnlyIfOs: ""

--- a/pkg/provider/testdata/ssm-custom-agent/expected.yaml
+++ b/pkg/provider/testdata/ssm-custom-agent/expected.yaml
@@ -141,6 +141,94 @@ Stages:
     UnpackImages: null
     Users: null
   - After: null
+    Commands: null
+    DataSources:
+      Path: ""
+      Providers: null
+    DeleteEntities: null
+    Directories: null
+    Dns:
+      DnsOptions: null
+      DnsSearch: null
+      Nameservers: null
+      Path: ""
+    Downloads: null
+    EnsureEntities: null
+    Environment: null
+    EnvironmentFile: ""
+    Files:
+    - Content: |
+        apiVersion: node.eks.aws/v1alpha1
+        kind: NodeConfig
+        metadata:
+          creationTimestamp: null
+        spec:
+          cluster:
+            name: eks-hybrid-cluster
+            region: us-east-1
+          containerd:
+            config: |
+              [plugins."io.containerd.grpc.v1.cri".containerd]
+              discard_unpacked_layers = false
+          hybrid:
+            ssm:
+              activationCode: 12345678-1234-1234-1234-123456789012
+              activationId: 12345678-1234-1234-1234-123456789012
+          instance:
+            localStorage: {}
+          kubelet:
+            config:
+              shutdownGracePeriod: 30s
+            flags:
+            - --node-labels=abc.company.com/test-label=true
+      Encoding: ""
+      Group: 0
+      Owner: 0
+      OwnerString: ""
+      Path: /opt/nodeadmutil/node-config.yaml
+      Permissions: 416
+    Git:
+      Auth:
+        Insecure: false
+        Password: ""
+        PrivateKey: ""
+        PublicKey: ""
+        Username: ""
+      Branch: ""
+      BranchOnly: false
+      Path: ""
+      URL: ""
+    Hostname: ""
+    If: ""
+    Layout:
+      Device: null
+      Expand: null
+      Parts: null
+    Modules: null
+    Name: Generate nodeadm config file
+    Node: ""
+    OnlyIfArch: ""
+    OnlyIfOs: ""
+    OnlyIfOsVersion: ""
+    OnlyIfServiceManager: ""
+    Packages:
+      Install: null
+      Refresh: false
+      Remove: null
+      Upgrade: false
+    SSHKeys: null
+    Sysctl: null
+    Systemctl:
+      Disable: null
+      Enable: null
+      Mask: null
+      Overrides: null
+      Start: null
+    SystemdFirstBoot: null
+    TimeSyncd: null
+    UnpackImages: null
+    Users: null
+  - After: null
     Commands:
     - 'bash /opt/nodeadmutil/scripts/nodeadm-install.sh 1.30.0 ssm /opt/nodeadmutil
       false '
@@ -239,94 +327,6 @@ Stages:
       Parts: null
     Modules: null
     Name: Run Nodeadm Upgrade
-    Node: ""
-    OnlyIfArch: ""
-    OnlyIfOs: ""
-    OnlyIfOsVersion: ""
-    OnlyIfServiceManager: ""
-    Packages:
-      Install: null
-      Refresh: false
-      Remove: null
-      Upgrade: false
-    SSHKeys: null
-    Sysctl: null
-    Systemctl:
-      Disable: null
-      Enable: null
-      Mask: null
-      Overrides: null
-      Start: null
-    SystemdFirstBoot: null
-    TimeSyncd: null
-    UnpackImages: null
-    Users: null
-  - After: null
-    Commands: null
-    DataSources:
-      Path: ""
-      Providers: null
-    DeleteEntities: null
-    Directories: null
-    Dns:
-      DnsOptions: null
-      DnsSearch: null
-      Nameservers: null
-      Path: ""
-    Downloads: null
-    EnsureEntities: null
-    Environment: null
-    EnvironmentFile: ""
-    Files:
-    - Content: |
-        apiVersion: node.eks.aws/v1alpha1
-        kind: NodeConfig
-        metadata:
-          creationTimestamp: null
-        spec:
-          cluster:
-            name: eks-hybrid-cluster
-            region: us-east-1
-          containerd:
-            config: |
-              [plugins."io.containerd.grpc.v1.cri".containerd]
-              discard_unpacked_layers = false
-          hybrid:
-            ssm:
-              activationCode: 12345678-1234-1234-1234-123456789012
-              activationId: 12345678-1234-1234-1234-123456789012
-          instance:
-            localStorage: {}
-          kubelet:
-            config:
-              shutdownGracePeriod: 30s
-            flags:
-            - --node-labels=abc.company.com/test-label=true
-      Encoding: ""
-      Group: 0
-      Owner: 0
-      OwnerString: ""
-      Path: /opt/nodeadmutil/node-config.yaml
-      Permissions: 416
-    Git:
-      Auth:
-        Insecure: false
-        Password: ""
-        PrivateKey: ""
-        PublicKey: ""
-        Username: ""
-      Branch: ""
-      BranchOnly: false
-      Path: ""
-      URL: ""
-    Hostname: ""
-    If: ""
-    Layout:
-      Device: null
-      Expand: null
-      Parts: null
-    Modules: null
-    Name: Generate nodeadm config file
     Node: ""
     OnlyIfArch: ""
     OnlyIfOs: ""

--- a/pkg/stages/init.go
+++ b/pkg/stages/init.go
@@ -3,99 +3,14 @@ package stages
 import (
 	"fmt"
 
-	"github.com/aws/eks-hybrid/api/v1alpha1"
 	yip "github.com/mudler/yip/pkg/schema"
-	"github.com/sirupsen/logrus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kyaml "sigs.k8s.io/yaml"
-
-	"github.com/kairos-io/provider-nodeadm/pkg/domain"
-)
-
-const (
-	nodeConfigFile     = "node-config.yaml"
-	nodeConfigTemplate = "node-config.tmpl"
 )
 
 // InitBootBeforeStages returns the boot.before stages required to run 'nodeadm init'.
-func InitBootBeforeStages(nc domain.NodeadmConfig, proxyArgs string, handleDependencies bool) []yip.Stage {
+func InitBootBeforeStages(proxyArgs string, handleDependencies bool) []yip.Stage {
 	return []yip.Stage{
-		initConfigStage(nc),
 		initStage(proxyArgs, handleDependencies),
 	}
-}
-
-func initConfigStage(nc domain.NodeadmConfig) yip.Stage {
-	bs, err := toHybridConfig(nc)
-	if err != nil {
-		logrus.Fatal(err)
-	}
-
-	initConfigStage := yip.Stage{
-		Name: "Generate nodeadm config file",
-		Files: []yip.File{
-			{
-				Path:        nodeConfigPath,
-				Permissions: 0640,
-				Content:     string(bs),
-			},
-		},
-	}
-
-	if nc.NodeConfiguration.IAMRolesAnywhere != nil {
-		initConfigStage.Files = append(initConfigStage.Files, []yip.File{
-			{
-				Path:        "/etc/iam/pki/server.pem",
-				Permissions: 0600,
-				Content:     nc.NodeConfiguration.IAMRolesAnywhere.Certificate,
-			},
-			{
-				Path:        "/etc/iam/pki/server.key",
-				Permissions: 0400,
-				Content:     nc.NodeConfiguration.IAMRolesAnywhere.PrivateKey,
-			},
-		}...)
-	}
-
-	return initConfigStage
-}
-
-func toHybridConfig(nc domain.NodeadmConfig) ([]byte, error) {
-	nodeConfig := v1alpha1.NodeConfig{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "node.eks.aws/v1alpha1",
-			Kind:       "NodeConfig",
-		},
-		ObjectMeta: metav1.ObjectMeta{},
-		Spec: v1alpha1.NodeConfigSpec{
-			Cluster: v1alpha1.ClusterDetails{
-				Name:   nc.NodeConfiguration.ClusterName,
-				Region: nc.NodeConfiguration.Region,
-			},
-			Hybrid: &v1alpha1.HybridOptions{
-				EnableCredentialsFile: false,
-			},
-		},
-	}
-	if nc.NodeConfiguration.UserConfig != nil {
-		nodeConfig.Spec.Containerd = nc.NodeConfiguration.UserConfig.Containerd
-		nodeConfig.Spec.Kubelet = nc.NodeConfiguration.UserConfig.Kubelet
-	}
-	if nc.NodeConfiguration.IAMRolesAnywhere != nil && nc.NodeConfiguration.IAMRolesAnywhere.RoleARN != "" {
-		nodeConfig.Spec.Hybrid.IAMRolesAnywhere = &v1alpha1.IAMRolesAnywhere{
-			NodeName:       nc.NodeConfiguration.IAMRolesAnywhere.NodeName,
-			TrustAnchorARN: nc.NodeConfiguration.IAMRolesAnywhere.TrustAnchorARN,
-			ProfileARN:     nc.NodeConfiguration.IAMRolesAnywhere.ProfileARN,
-			RoleARN:        nc.NodeConfiguration.IAMRolesAnywhere.RoleARN,
-		}
-	}
-	if nc.NodeConfiguration.SSM != nil && nc.NodeConfiguration.SSM.ActivationCode != "" {
-		nodeConfig.Spec.Hybrid.SSM = &v1alpha1.SSM{
-			ActivationCode: nc.NodeConfiguration.SSM.ActivationCode,
-			ActivationID:   nc.NodeConfiguration.SSM.ActivationID,
-		}
-	}
-	return kyaml.Marshal(nodeConfig)
 }
 
 func initStage(proxyArgs string, handleDependencies bool) yip.Stage {


### PR DESCRIPTION
Fixes side effect of https://github.com/kairos-io/provider-nodeadm/pull/31.

Now that the upgrade script doesn't exit when no-ops are detected, the nodeadm config must exist before the upgrade script is executed, since the upgrade script will always invoke `nodeadm init`.